### PR TITLE
Ver. 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gemini-discord-bot
 
 これは簡易的なDiscordチャットボットです。Geminiとの会話機能が実装されています。
-@konoka-iori が個人的に使用するために作成されました。主に小規模なDiscordサーバーでの利用を想定しています。
+[@konoka-iori](https://github.com/konoka-iori) が個人的に使用するために作成されました。主に小規模なDiscordサーバーでの利用を想定しています。
 Gemini APIを使ったDiscordのチャットボット作ってみたいよという人はぜひ参考にしてみてくださいね。
 
 # 機能一覧と使い方
@@ -34,9 +34,12 @@ Gemini APIを使ったDiscordのチャットボット作ってみたいよとい
 
 このBOTを正常に動作させるには以下の権限が必須です。
 
-SCOPES: bot
+SCOPES:
 
-BOT PERMISSIONS:
+- bot
+- applications.commands
+
+BOT PERMISSIONS / TEXT PERMISSIONS:
 
 - Send Messages
 - Send Messages in Threads (スレッド内でもBOTを利用したい場合は必須)
@@ -61,22 +64,22 @@ BOT PERMISSIONS:
 
 # バージョン履歴
 
-- `1.0`:
+- [1.0](https://github.com/konoka-iori/gemini-discord-bot/pull/1):
   - 初版リリース（ `/about` と `/chat` の追加）
-- `1.1`:
+- [1.1](https://github.com/konoka-iori/gemini-discord-bot/pull/7):
   - ユーザーが送信した内容を返信に表示するよう改善 [#3](https://github.com/konoka-iori/gemini-discord-bot/issues/2)
-- `1.2`:
+- [1.2](https://github.com/konoka-iori/gemini-discord-bot/pull/10):
   - Pythonのバージョンを3.9から3.11に変更
   - 不具合修正 [#9](https://github.com/konoka-iori/gemini-discord-bot/issues/9)
-- `1.3`:
+- [1.3](https://github.com/konoka-iori/gemini-discord-bot/pull/12):
   - ドキュメントの拡充 [#6](https://github.com/konoka-iori/gemini-discord-bot/issues/6)
   - 不具合修正 [#11](https://github.com/konoka-iori/gemini-discord-bot/issues/11)
   - `/about` のEmbedを変更
   - EmbedのタイムスタンプをUTC時間に変換し、より正確なタイムスタンプを表示できるように対応
-- `2.0`:
+- [2.0](https://github.com/konoka-iori/gemini-discord-bot/pull/14):
   - 機能追加 [#2](https://github.com/konoka-iori/gemini-discord-bot/issues/2)
   - ドキュメント修正
-- `2.1`:
+- `[2.1](https://github.com/konoka-iori/gemini-discord-bot/pull/17):
   - JSONの形式を更新 [#15](https://github.com/konoka-iori/gemini-discord-bot/issues/15)
   - グローバルコマンドに対応
   - 依存関係を更新
@@ -85,3 +88,11 @@ BOT PERMISSIONS:
   - 全体的なリファクタリングを実施
   - `/about` のEmbedを変更
   - ドキュメント修正
+- [2.2](https://github.com/konoka-iori/gemini-discord-bot/pull/21):
+  - `/ping` コマンドを追加 [#19](https://github.com/konoka-iori/gemini-discord-bot/issues/19)
+  - 回答にかかった時間がEmbedに表示されるように変更
+  - Embedのフッターとタイムスタンプを追加
+  - `/about` のEmbedに `/ping` の説明を追加し、スラッシュコマンドのリンクを追加
+  - 不具合修正（グローバルコマンドが正常に同期されない問題を修正）
+  - コードのリファクタリング
+  - ドキュメント修正（botの権限設定を追加）

--- a/json/command.json
+++ b/json/command.json
@@ -4,6 +4,11 @@
         "value": "",
         "embed": "json/embed/about.json"
     },
+    "ping": {
+        "description": "BOTの生存確認を行い、応答速度を表示します。",
+        "value": "",
+        "embed": ""
+    },
     "chat": {
         "description": "Gemini-Proと会話できます。",
         "value": "",

--- a/json/embed/about.json
+++ b/json/embed/about.json
@@ -4,11 +4,15 @@
   "description": "これは簡易的なDiscordチャットボットです。Geminiとの会話機能が実装されています。\nこのBOTのソースコードは[GitHub](https://github.com/konoka-iori/gemini-discord-bot)で公開されています。\n不具合報告、機能追加要望などはIssueください。Pull Requestも歓迎です！",
   "fields": [
     {
-      "name": "</about:1196637313560748052>",
+      "name": "</about:1217373559039463424>",
       "value": "BOTの説明を表示します。\nそう、このメッセージのことです。"
     },
     {
-      "name": "</chat:1196637313560748053>",
+      "name": "</ping:1234497862688313454>",
+      "value": "BOTやAPIの生存確認を行い、応答速度を表示します。\n- `Discord WebSocket` はBOTサーバーとDiscord APIの間のレイテンシです。\n- `Discord API Endpoint` はユーザーが `/ping` コマンドを送信してからBOTが返答するまでのレイテンシです。\n- `Gemini API` はGemini APIに「ping」とメッセージを送信し、Geminiが返答するまでのレイテンシです。"
+    },
+    {
+      "name": "</chat:1234497862688313455>",
       "value": "Geminiとチャットができます。一問一答方式で、会話履歴はBOT側に保存されません。\n使用されるモデルは `gemini-1.5-pro-latest` です。\n\nGemini APIを利用しています。Geminiの概要、利用規約などについては公式サイト等を確認してください。\n会話内容はGemini APIに送信され、Gemini側で保存されて学習等に利用される可能性があります。詳しくはGemini APIの公式サイト等を確認してください。"
     },
     {
@@ -21,5 +25,5 @@
     "text": "Konoka-Iori",
     "icon_url": "https://images-ext-2.discordapp.net/external/YqkAi85wPTOxQ5VH73CbwucysCTlnN6gyFHX4ZOGeqI/https/avatars.githubusercontent.com/u/70302978"
   },
-  "timestamp": 1713006000
+  "timestamp": 1714401000
 }

--- a/json/embed/about.json
+++ b/json/embed/about.json
@@ -4,11 +4,11 @@
   "description": "これは簡易的なDiscordチャットボットです。Geminiとの会話機能が実装されています。\nこのBOTのソースコードは[GitHub](https://github.com/konoka-iori/gemini-discord-bot)で公開されています。\n不具合報告、機能追加要望などはIssueください。Pull Requestも歓迎です！",
   "fields": [
     {
-      "name": "`/about`",
+      "name": "</about:1196637313560748052>",
       "value": "BOTの説明を表示します。\nそう、このメッセージのことです。"
     },
     {
-      "name": "`/chat`",
+      "name": "</chat:1196637313560748053>",
       "value": "Geminiとチャットができます。一問一答方式で、会話履歴はBOT側に保存されません。\n使用されるモデルは `gemini-1.5-pro-latest` です。\n\nGemini APIを利用しています。Geminiの概要、利用規約などについては公式サイト等を確認してください。\n会話内容はGemini APIに送信され、Gemini側で保存されて学習等に利用される可能性があります。詳しくはGemini APIの公式サイト等を確認してください。"
     },
     {

--- a/src/bot.py
+++ b/src/bot.py
@@ -19,7 +19,7 @@ client = discord.Client(intents=discord.Intents.all())
 tree = discord.app_commands.CommandTree(client)
 
 
-def generate_chat_embed(ctx:discord.Integration, message:str) -> tuple[discord.Embed, discord.Embed]:
+def generate_chat_embed(ctx:discord.interactions.Interaction, message:str) -> tuple[discord.Embed, discord.Embed]:
     response = chat_data.get_response(message)
     user_embed = discord.Embed(description=message[:2048], color=discord.Color.green())
     user_embed.set_author(name=ctx.user.name, icon_url=ctx.user.avatar.url)
@@ -30,13 +30,13 @@ def generate_chat_embed(ctx:discord.Integration, message:str) -> tuple[discord.E
 
 
 @tree.command(name="about", description=command_data.get_command_description("about"))
-async def command_about(ctx:discord.Interaction) -> None:
+async def command_about(ctx:discord.interactions.Interaction) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
         await ctx.followup.send(embed=discord.Embed.from_dict(command_data.get_command_embed("about")))
 
 @tree.command(name="ping", description=command_data.get_command_description("ping"))
-async def command_ping(ctx:discord.Interaction) -> None:
+async def command_ping(ctx:discord.interactions.Interaction) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
         embed = discord.Embed(title=":ping_pong: pong!")
@@ -46,13 +46,14 @@ async def command_ping(ctx:discord.Interaction) -> None:
         await ctx.followup.send(embed=embed)
 
 @tree.command(name="chat", description=command_data.get_command_description("chat"))
-async def command_chat(ctx:discord.Interaction, message:str) -> None:
+async def command_chat(ctx:discord.interactions.Interaction, message:str) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
+        print(type(ctx))
         await ctx.followup.send(embeds=generate_chat_embed(ctx=ctx, message=message))
 
 @tree.context_menu(name="Gemini replies to message")
-async def command_reply(ctx:discord.Interaction, message:discord.Message) -> None:
+async def command_reply(ctx:discord.interactions.Interaction, message:discord.Message) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
         await ctx.followup.send(embeds=generate_chat_embed(ctx=ctx, message=message.content))

--- a/src/bot.py
+++ b/src/bot.py
@@ -33,8 +33,7 @@ def generate_chat_embed(ctx:discord.Integration, message:str) -> tuple[discord.E
 async def command_about(ctx:discord.Interaction) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
-        embed = discord.Embed.from_dict(command_data.get_command_embed("about"))
-        await ctx.followup.send(embed=embed)
+        await ctx.followup.send(embed=discord.Embed.from_dict(command_data.get_command_embed("about")))
 
 @tree.command(name="ping", description=command_data.get_command_description("ping"))
 async def command_ping(ctx:discord.Interaction) -> None:
@@ -62,6 +61,7 @@ async def command_reply(ctx:discord.Interaction, message:discord.Message) -> Non
 @client.event
 async def on_ready() -> None:
     print(f"LOGGED IN: {client.user.name}")
+    tree.clear_commands(guild=DISCORD_SERVER_ID) # コマンドをクリア
     tree.copy_global_to(guild=DISCORD_SERVER_ID)
     await tree.sync(guild=DISCORD_SERVER_ID) # コマンドを同期
     print("COMMAND SYNCED")

--- a/src/bot.py
+++ b/src/bot.py
@@ -40,9 +40,11 @@ async def command_ping(ctx:discord.Interaction) -> None:
 async def command_chat(ctx:discord.Interaction, message:str) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
+        response = chat_data.get_response(message)
         user_embed = discord.Embed(description=message[:2048], color=discord.Color.green())
         user_embed.set_author(name=ctx.user.name, icon_url=ctx.user.avatar.url)
-        response_embed = discord.Embed(description=chat_data.get_response(message)[:2048], color=discord.Color.blue())
+        response_embed = discord.Embed(description=response[0][:2048], color=discord.Color.blue())
+        response_embed.add_field(name="回答にかかった時間", value=f"{round(response[1], 2)} ms", inline=False)
         response_embed.set_author(name=model_data.get_name(), icon_url=model_data.get_icon())
         await ctx.followup.send(embeds=[user_embed, response_embed])
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -62,7 +62,7 @@ async def command_reply(ctx:discord.Interaction, message:discord.Message) -> Non
 async def on_ready() -> None:
     print(f"LOGGED IN: {client.user.name}")
     tree.copy_global_to(guild=DISCORD_SERVER_ID)
-    await tree.sync(guild=DISCORD_SERVER_ID) # コマンドを同期
+    await tree.sync() # コマンドを同期
     print("COMMAND SYNCED")
     await client.change_presence(status=discord.Status.online, activity=discord.CustomActivity(name="Gemini 1.5 Proを実行中"))
     print("PRESENCE UPDATED")

--- a/src/bot.py
+++ b/src/bot.py
@@ -61,7 +61,6 @@ async def command_reply(ctx:discord.Interaction, message:discord.Message) -> Non
 @client.event
 async def on_ready() -> None:
     print(f"LOGGED IN: {client.user.name}")
-    tree.clear_commands(guild=DISCORD_SERVER_ID) # コマンドをクリア
     tree.copy_global_to(guild=DISCORD_SERVER_ID)
     await tree.sync(guild=DISCORD_SERVER_ID) # コマンドを同期
     print("COMMAND SYNCED")

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,5 +1,6 @@
 from os import getenv
 from time import time
+from datetime import datetime
 import discord
 import discord.app_commands
 import chat
@@ -23,9 +24,13 @@ def generate_chat_embed(ctx:discord.interactions.Interaction, message:str) -> tu
     response = chat_data.get_response(message)
     user_embed = discord.Embed(description=message[:2048], color=discord.Color.green())
     user_embed.set_author(name=ctx.user.name, icon_url=ctx.user.avatar.url)
+    user_embed.set_footer(text="User Prompt")
+    user_embed.timestamp = ctx.created_at
     response_embed = discord.Embed(description=response[0][:2048], color=discord.Color.blue())
     response_embed.add_field(name="回答にかかった時間", value=f"{round(response[1], 2)} ms", inline=False)
     response_embed.set_author(name=model_data.get_name(), icon_url=model_data.get_icon())
+    response_embed.set_footer(text=model_data.get_model_name())
+    response_embed.timestamp = datetime.now()
     return user_embed, response_embed
 
 
@@ -49,7 +54,6 @@ async def command_ping(ctx:discord.interactions.Interaction) -> None:
 async def command_chat(ctx:discord.interactions.Interaction, message:str) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
-        print(type(ctx))
         await ctx.followup.send(embeds=generate_chat_embed(ctx=ctx, message=message))
 
 @tree.context_menu(name="Gemini replies to message")

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,8 +1,10 @@
+from datetime import datetime
 from os import getenv
 from time import time
-from datetime import datetime
+
 import discord
 import discord.app_commands
+
 import chat
 import json_load
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,4 +1,5 @@
 from os import getenv
+from time import time
 import discord
 import discord.app_commands
 import chat
@@ -23,6 +24,16 @@ async def command_about(ctx:discord.Interaction) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
         embed = discord.Embed.from_dict(command_data.get_command_embed("about"))
+        await ctx.followup.send(embed=embed)
+
+@tree.command(name="ping", description=command_data.get_command_description("ping"))
+async def command_ping(ctx:discord.Interaction) -> None:
+    async with ctx.channel.typing():
+        await ctx.response.defer(thinking=True)
+        embed = discord.Embed(title=":ping_pong: pong!")
+        embed.add_field(name=":globe_with_meridians: Discord WebSocket", value=f"{round(client.latency, 2)} ms", inline=True)
+        embed.add_field(name=":link: Discord API Endpoint", value=f"{round(time() - ctx.created_at.timestamp(), 2)} ms", inline=True)
+        embed.add_field(name=":speech_balloon: Gemini API", value=str(chat_data.ping()), inline=False)
         await ctx.followup.send(embed=embed)
 
 @tree.command(name="chat", description=command_data.get_command_description("chat"))

--- a/src/bot.py
+++ b/src/bot.py
@@ -49,13 +49,13 @@ async def command_ping(ctx:discord.Interaction) -> None:
 async def command_chat(ctx:discord.Interaction, message:str) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
-        await ctx.followup.send(embeds=generate_chat_embed(ctx, message))
+        await ctx.followup.send(embeds=generate_chat_embed(ctx=ctx, message=message))
 
 @tree.context_menu(name="Gemini replies to message")
 async def command_reply(ctx:discord.Interaction, message:discord.Message) -> None:
     async with ctx.channel.typing():
         await ctx.response.defer(thinking=True)
-        await ctx.followup.send(embeds=generate_chat_embed(ctx, message.content))
+        await ctx.followup.send(embeds=generate_chat_embed(ctx=ctx, message=message.content))
 
 
 @client.event

--- a/src/bot.py
+++ b/src/bot.py
@@ -45,13 +45,16 @@ async def command_reply(ctx:discord.Interaction, message:discord.Message) -> Non
         response_embed.set_author(name=model_data.get_name, icon_url=model_data.get_icon)
         await ctx.followup.send(embeds=[user_embed, response_embed])
 
+
 @client.event
 async def on_ready() -> None:
     print(f"LOGGED IN: {client.user.name}")
     tree.copy_global_to(guild=DISCORD_SERVER_ID)
-    await tree.sync(guild=DISCORD_SERVER_ID) #コマンド同期
+    await tree.sync(guild=DISCORD_SERVER_ID) # コマンドを同期
     print("COMMAND SYNCED")
     await client.change_presence(status=discord.Status.online, activity=discord.CustomActivity(name="Gemini 1.5 Proを実行中"))
+    print("PRESENCE UPDATED")
+
 
 # Discordに接続
 client.run(DISCORD_BOT_TOKEN)

--- a/src/chat.py
+++ b/src/chat.py
@@ -19,10 +19,18 @@ class Chat:
         except Exception as e:
             return f"エラーが発生しました。以下の内容をコピペして管理者までお知らせください。\n```{e}```", float(0)
 
+    def ping(self) -> str:
+        response = self.get_response("ping")
+        if response[1] == 0:
+            return str(response[0])
+        else:
+            return f"{round(response[1], 2)} ms"
+
 
 if __name__ == "__main__":
     from os import getenv
     chat = Chat(token=getenv("GEMINI_API_KEY"), model="gemini-1.5-pro-latest") #type: ignore
     test_response = chat.get_response("自己紹介してください。")
     print(test_response[0] + f"\n処理時間: {test_response[1]}")
+    print(chat.ping())
     #print(chat.get_response(input(">>> ")))

--- a/src/chat.py
+++ b/src/chat.py
@@ -5,13 +5,13 @@ import google.generativeai as gemini
 class Chat:
     def __init__(self, token:str, model:str) -> None:
         self.__token = token
-        self.model = model
+        self.__model = model
 
     def get_response(self, message:str) -> tuple[str, float]:
         try:
             gemini.configure(api_key=self.__token)
             config = {"max_output_tokens": 1000}
-            model = gemini.GenerativeModel(model_name=self.model, generation_config=config)
+            model = gemini.GenerativeModel(model_name=self.__model, generation_config=config)
             start = time()
             response = model.generate_content(message)
             end = time()

--- a/src/chat.py
+++ b/src/chat.py
@@ -1,22 +1,28 @@
+from time import time
 import google.generativeai as gemini
+
 
 class Chat:
     def __init__(self, token:str, model:str) -> None:
         self.token = token
         self.model = model
 
-    def get_response(self, message:str) -> str:
+    def get_response(self, message:str) -> tuple[str, float]:
         try:
             gemini.configure(api_key=self.token)
             config = {"max_output_tokens": 1000}
             model = gemini.GenerativeModel(model_name=self.model, generation_config=config)
-            return str(model.generate_content(message).text)
+            start = time()
+            response = model.generate_content(message)
+            end = time()
+            return str(response.text), float(end - start)
         except Exception as e:
-            return f"エラーが発生しました。以下の内容をコピペして管理者までお知らせください。\n```{e}```"
+            return f"エラーが発生しました。以下の内容をコピペして管理者までお知らせください。\n```{e}```", float(0)
 
 
 if __name__ == "__main__":
     from os import getenv
     chat = Chat(token=getenv("GEMINI_API_KEY"), model="gemini-1.5-pro-latest") #type: ignore
-    print(chat.get_response("自己紹介してください。"))
+    test_response = chat.get_response("自己紹介してください。")
+    print(test_response[0] + f"\n処理時間: {test_response[1]}")
     #print(chat.get_response(input(">>> ")))

--- a/src/chat.py
+++ b/src/chat.py
@@ -1,4 +1,5 @@
 from time import time
+
 import google.generativeai as gemini
 
 

--- a/src/chat.py
+++ b/src/chat.py
@@ -4,12 +4,12 @@ import google.generativeai as gemini
 
 class Chat:
     def __init__(self, token:str, model:str) -> None:
-        self.token = token
+        self.__token = token
         self.model = model
 
     def get_response(self, message:str) -> tuple[str, float]:
         try:
-            gemini.configure(api_key=self.token)
+            gemini.configure(api_key=self.__token)
             config = {"max_output_tokens": 1000}
             model = gemini.GenerativeModel(model_name=self.model, generation_config=config)
             start = time()

--- a/src/json_load.py
+++ b/src/json_load.py
@@ -1,6 +1,7 @@
-from genericpath import isdir, isfile
-from datetime import datetime, timezone
 import json
+from datetime import datetime, timezone
+
+from genericpath import isdir, isfile
 
 
 class JsonLoader:

--- a/src/json_load.py
+++ b/src/json_load.py
@@ -1,5 +1,5 @@
 from genericpath import isdir, isfile
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 
 
@@ -35,7 +35,7 @@ class jsonLoad(JsonLoader):
         if "color" in embed:
             embed["color"] = int(embed["color"].lstrip("#"), 16)
         if "timestamp" in embed:
-            embed["timestamp"] = datetime.utcfromtimestamp(int(embed["timestamp"])).isoformat()
+            embed["timestamp"] = datetime.fromtimestamp(int(embed["timestamp"]), tz=timezone.utc).isoformat()
         return embed
 
     def __get_command(self, command:str, key:str) -> str | None:


### PR DESCRIPTION
## 変更

- カスタムアクティビティが更新されたことをprintするように変更
- `get_response` 関数が処理時間を計測するように変更
- 回答にかかった時間がEmbedに追加されるよう変更
- `/about` のEmbedにあったスラッシュコマンドの説明をリンク化

## 新機能

- `/ping` コマンドを追加

## 不具合修正

- グローバルコマンドの同期が正常に行われない問題を修正

## リファクタリング

- 非推奨のメソッドをやめて推奨されるものに変更
- 一部の変数をprivate変数にしてより安全にした
- `command_chat` と `command_reply` はほぼ同じ内部処理をしているので、共通化
- `command_about` の処理をより簡潔に記述
- `bot.py` の各関数の型ヒントを修正
- 各ファイルのimport文をisortで整理